### PR TITLE
Made playtest file downloader a separate service.

### DIFF
--- a/BotHATTwaffle/BotHATTwaffle.csproj
+++ b/BotHATTwaffle/BotHATTwaffle.csproj
@@ -209,6 +209,9 @@
     <Compile Include="Modules\Moderation.cs" />
     <Compile Include="Modules\TimerService.cs" />
     <Compile Include="Modules\UtilityService.cs" />
+    <Compile Include="Objects\Downloader\Downloader.cs" />
+    <Compile Include="Objects\Downloader\FtpDownloader.cs" />
+    <Compile Include="Objects\Downloader\SftpDownloader.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Objects\UserData.cs" />

--- a/BotHATTwaffle/BotHATTwaffle.csproj
+++ b/BotHATTwaffle/BotHATTwaffle.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Modules\TimerService.cs" />
     <Compile Include="Modules\UtilityService.cs" />
     <Compile Include="Objects\Downloader\Downloader.cs" />
+    <Compile Include="Objects\Downloader\DownloaderService.cs" />
     <Compile Include="Objects\Downloader\FtpDownloader.cs" />
     <Compile Include="Objects\Downloader\SftpDownloader.cs" />
     <Compile Include="Program.cs" />

--- a/BotHATTwaffle/DataService.cs
+++ b/BotHATTwaffle/DataService.cs
@@ -16,6 +16,7 @@ using Renci.SshNet.Sftp;
 using Discord;
 using Discord.WebSocket;
 using System.Web;
+using BotHATTwaffle.Objects.Downloader;
 
 namespace BotHATTwaffle
 {
@@ -724,132 +725,21 @@ namespace BotHATTwaffle
         {
             Console.ForegroundColor = ConsoleColor.Cyan;
 
-            if (server.FTPType.ToLower() == "ftps" || server.FTPType.ToLower() == "ftp")
-                DownloadFTPorFTPS(testInfo, server);
-            if (server.FTPType.ToLower() == "sftp")
-                DownloadSFTP(testInfo, server);
+            switch (server.FTPType.ToLower()) {
+                case "ftps":
+                case "ftp":
+                    using (var dl = new FtpDownloader(testInfo, server, demoPath))
+                        dl.Download();
+
+                    break;
+                case "sftp":
+                    using (var dl = new SftpDownloader(testInfo, server, demoPath))
+                        dl.Download();
+
+                    break;
+            }
 
             Console.ResetColor();
-        }
-
-        private void DownloadSFTP(string[] testInfo, JsonServer server)
-        {
-            DateTime time = Convert.ToDateTime(testInfo[1]);
-            var workshopID = Regex.Match(testInfo[6], @"\d+$").Value;
-            string demoName = $"{time.ToString("MM_dd_yyyy")}_{testInfo[2].Substring(0, testInfo[2].IndexOf(" "))}";
-            string localPath = $"{demoPath}\\{time.ToString("yyyy")}\\{time.ToString("MM")} - {time.ToString("MMMM")}\\{demoName}";
-
-            using (SftpClient sftp = new SftpClient(testInfo[10], server.FTPUser, server.FTPPass))
-            {
-                try
-                {
-                    sftp.Connect();
-                    var files = sftp.ListDirectory(server.FTPPath);
-                    SftpFile remoteDemoFile = null;
-                    foreach (var file in files)
-                    {
-                        if (file.Name.ToLower().Contains(demoName.ToLower()))
-                        {
-                            remoteDemoFile = file;
-                        }
-                    }
-                    files = sftp.ListDirectory($"{server.FTPPath}/maps/workshop/{workshopID}");
-                    SftpFile remoteBSPFile = null;
-                    foreach (var file in files)
-                    {
-                        if (file.Name.ToLower().Contains(".bsp"))
-                        {
-                            remoteBSPFile = file;
-                        }
-                    }
-                    string localPathDemFile = $"{localPath}\\{remoteDemoFile.Name}";
-                    string localPathBSPFile = $"{localPath}\\{remoteBSPFile.Name}";
-
-                    Directory.CreateDirectory(localPath);
-                    ChannelLog($"Getting Demo File From Playtest",$"{remoteDemoFile.FullName}\n{localPathDemFile}");
-                    using (Stream fileStreamDem = File.OpenWrite(localPathDemFile))
-                    {
-                        sftp.DownloadFile(remoteDemoFile.FullName, fileStreamDem);
-                    }
-
-                    ChannelLog($"Getting BSP File From Playtest", $"{remoteBSPFile.FullName}\n{localPathBSPFile}");
-                    using (Stream fileStreamBSP = File.OpenWrite(localPathBSPFile))
-                    {
-                        sftp.DownloadFile(remoteBSPFile.FullName, fileStreamBSP);
-                    }
-
-                    sftp.Disconnect();
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine("An exception has been caught " + e.ToString());
-                }
-            }
-
-            var listFiles = Directory.GetFiles(localPath);
-            ChannelLog($"Download complete!", $"{string.Join("\n", listFiles)}");
-        }
-
-        //Download files over FTPS
-        private void DownloadFTPorFTPS(string[] testInfo, JsonServer server)
-        {
-            using (FtpClient client = new FtpClient(server.Address, server.FTPUser, server.FTPPass))
-            {
-                if (server.FTPType == "ftps")
-                {
-                    client.EncryptionMode = FtpEncryptionMode.Explicit;
-                    client.SslProtocols = SslProtocols.Tls;
-                    client.ValidateCertificate += new FtpSslValidation(OnValidateCertificate);
-                }
-                client.Connect();
-
-                //Setup variables for getting the files.
-                string workshopID = Regex.Match(testInfo[6], @"\d+$").Value;
-                DateTime time = Convert.ToDateTime(testInfo[1]);
-                string demoName = $"{time.ToString("MM_dd_yyyy")}_{testInfo[2].Substring(0, testInfo[2].IndexOf(" "))}";
-                string localPath = $"{demoPath}\\{time.ToString("yyyy")}\\{time.ToString("MM")} - {time.ToString("MMMM")}\\{demoName}";
-                string localPathDemoFile = $"{localPath}\\{demoName}_{testInfo[7]}.dem";
-
-                //Make local directory for storing demo
-                Directory.CreateDirectory(localPath);
-
-                //Find the remote path to the demo file
-                string[] fileList = client.GetNameListing(server.FTPPath);
-                string demoFTPPath = null;
-                foreach (var s in fileList)
-                {
-                    if (s.Contains($"{demoName.ToLower()}") || s.Contains($"{demoName}"))
-                    {
-                        demoFTPPath = s;
-                    }
-                }
-
-                //Get the BSP paths
-                string serverFTPBSPPath = $"{server.FTPPath}/maps/workshop/{workshopID}";
-                fileList = client.GetNameListing(serverFTPBSPPath);
-                string bspFTPPath = null;
-                foreach (string s in fileList)
-                {
-                    if (s.Contains(".bsp"))
-                        bspFTPPath = s;
-                }
-                string localPathBSPFile = $"{localPath}\\{Path.GetFileName(bspFTPPath)}";
-
-                //Download Demo and BSP
-                ChannelLog($"Getting Demo File From Playtest", $"{demoFTPPath}\n{localPathDemoFile}");
-                client.DownloadFile(localPathDemoFile, demoFTPPath);
-
-                ChannelLog($"Getting BSP File From Playtest", $"{bspFTPPath}\n{localPathBSPFile}");
-                client.DownloadFile(localPathBSPFile, bspFTPPath);
-
-                var listFiles = Directory.GetFiles(localPath);
-                ChannelLog($"Download complete!",$"{string.Join("\n", listFiles)}");
-            }
-        }
-
-        private static void OnValidateCertificate(FtpClient control, FtpSslValidationEventArgs e)
-        {
-            e.Accept = true;
         }
     }
 }

--- a/BotHATTwaffle/DataService.cs
+++ b/BotHATTwaffle/DataService.cs
@@ -8,11 +8,6 @@ using HtmlAgilityPack;
 using System.Threading.Tasks;
 using CoreRCON;
 using System.Net;
-using FluentFTP;
-using System.Security.Authentication;
-using System.Text.RegularExpressions;
-using Renci.SshNet;
-using Renci.SshNet.Sftp;
 using Discord;
 using Discord.WebSocket;
 using System.Web;
@@ -30,7 +25,7 @@ namespace BotHATTwaffle
         List<JsonSeries> series;
         List<JsonServer> servers;
         Random _random;
-        private string demoPath;
+        public string DemoPath;
 
         //Channels and Role vars
         string logChannelStr;
@@ -150,7 +145,7 @@ namespace BotHATTwaffle
             mainConfig.AddKeyIfMissing("playTesterRole", "Playtester");
             mainConfig.AddKeyIfMissing("activeMemberRole", "Active Member");
             mainConfig.AddKeyIfMissing("testingChannel", "csgo_level_testing");
-            mainConfig.AddKeyIfMissing("demoPath", $"X:\\Playtesting Demos");
+            mainConfig.AddKeyIfMissing("DemoPath", $"X:\\Playtesting Demos");
             mainConfig.AddKeyIfMissing("casualConfig", $"thw");
             mainConfig.AddKeyIfMissing("compConfig", $"thw");
             mainConfig.AddKeyIfMissing("postConfig", $"postame");
@@ -188,8 +183,8 @@ namespace BotHATTwaffle
 
         private void VariableAssignment()
         {
-            if (config.ContainsKey("demoPath"))
-                demoPath = (config["demoPath"]);
+            if (config.ContainsKey("DemoPath"))
+                DemoPath = (config["DemoPath"]);
             if (config.ContainsKey("pakRatEavesDropCSV"))
                 pakRatEavesDrop = (config["pakRatEavesDropCSV"]).Split(',');
             if (config.ContainsKey("howToPackEavesDropCSV"))
@@ -719,27 +714,6 @@ namespace BotHATTwaffle
                 //Do nothing. The command that called this will handle the no results found message.
             }
             return listResults;
-        }
-
-        public void GetPlayTestFiles(string[] testInfo, JsonServer server)
-        {
-            Console.ForegroundColor = ConsoleColor.Cyan;
-
-            switch (server.FTPType.ToLower()) {
-                case "ftps":
-                case "ftp":
-                    using (var dl = new FtpDownloader(testInfo, server, demoPath))
-                        dl.Download();
-
-                    break;
-                case "sftp":
-                    using (var dl = new SftpDownloader(testInfo, server, demoPath))
-                        dl.Download();
-
-                    break;
-            }
-
-            Console.ResetColor();
         }
     }
 }

--- a/BotHATTwaffle/Objects/Downloader/Downloader.cs
+++ b/BotHATTwaffle/Objects/Downloader/Downloader.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using BotHATTwaffle.Modules.Json;
 
 namespace BotHATTwaffle.Objects.Downloader

--- a/BotHATTwaffle/Objects/Downloader/Downloader.cs
+++ b/BotHATTwaffle/Objects/Downloader/Downloader.cs
@@ -8,26 +8,24 @@ namespace BotHATTwaffle.Objects.Downloader
     public abstract class Downloader<TClient> : IDisposable
         where TClient : IDisposable
     {
-        protected TClient Client { get; set; }
-
-        protected string DemoName { get; }
-
-        protected string FtpPath { get; }
-
-        protected string LocalPath { get; }
-
-        protected string WorkshopId { get; }
+        protected TClient Client;
+        protected readonly DataServices DataSvc;
+        protected readonly string DemoName;
+        protected readonly string FtpPath;
+        protected readonly string LocalPath;
+        protected readonly string WorkshopId;
 
         protected Downloader(IReadOnlyList<string> testInfo,
                              JsonServer server,
-                             string demoPath)
+                             DataServices dataSvc)
         {
+            DataSvc = dataSvc;
             DateTime time = Convert.ToDateTime(testInfo[1]);
             string title = testInfo[2].Substring(0, testInfo[2].IndexOf(" "));
 
             DemoName = $"{time:MM_dd_yyyy}_{title}";
             FtpPath = server.FTPPath;
-            LocalPath = $"{demoPath}\\{time:yyyy}\\{time:MM} - " +
+            LocalPath = $"{DataSvc.DemoPath}\\{time:yyyy}\\{time:MM} - " +
                         $"{time:MMMM}\\{DemoName}";
             WorkshopId = Regex.Match(testInfo[6], @"\d+$").Value;
         }

--- a/BotHATTwaffle/Objects/Downloader/Downloader.cs
+++ b/BotHATTwaffle/Objects/Downloader/Downloader.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using BotHATTwaffle.Modules.Json;
+
+namespace BotHATTwaffle.Objects.Downloader
+{
+    public abstract class Downloader<TClient> : IDisposable
+        where TClient : IDisposable
+    {
+        protected TClient Client { get; set; }
+
+        protected string DemoName { get; }
+
+        protected string FtpPath { get; }
+
+        protected string LocalPath { get; }
+
+        protected string WorkshopId { get; }
+
+        protected Downloader(IReadOnlyList<string> testInfo,
+                             JsonServer server,
+                             string demoPath)
+        {
+            DateTime time = Convert.ToDateTime(testInfo[1]);
+            string title = testInfo[2].Substring(0, testInfo[2].IndexOf(" "));
+
+            DemoName = $"{time:MM_dd_yyyy}_{title}";
+            FtpPath = server.FTPPath;
+            LocalPath = $"{demoPath}\\{time:yyyy}\\{time:MM} - " +
+                        $"{time:MMMM}\\{DemoName}";
+            WorkshopId = Regex.Match(testInfo[6], @"\d+$").Value;
+        }
+
+        public abstract void Download();
+
+        public void Dispose()
+        {
+            Client.Dispose();
+        }
+    }
+}

--- a/BotHATTwaffle/Objects/Downloader/DownloaderService.cs
+++ b/BotHATTwaffle/Objects/Downloader/DownloaderService.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BotHATTwaffle.Modules.Json;
+
+namespace BotHATTwaffle.Objects.Downloader {
+    public class DownloaderService {
+        private DataServices DataSvc { get; }
+
+        private BackgroundWorker Worker { get; }
+
+        public DownloaderService(DataServices ds)
+        {
+            DataSvc = ds;
+            Worker = new BackgroundWorker();
+
+            // DownloadFiles is used as the DoWork event.
+            Worker.DoWork += DownloadFiles;
+        }
+
+        public void Start(IReadOnlyList<string> testInfo, JsonServer server)
+        {
+            if (!Worker.IsBusy)
+            {
+                // RunWorkerAsync raises the DoWork event.
+                Worker.RunWorkerAsync((DataSvc, testInfo, server));
+            }
+        }
+
+        private void DownloadFiles(object sender, DoWorkEventArgs e)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            var (testInfo, server) =
+                (ValueTuple<IReadOnlyList<string>, JsonServer>) e.Argument;
+
+            switch (server.FTPType.ToLower())
+            {
+                case "ftps":
+                case "ftp":
+                    using (var dl = new FtpDownloader(testInfo, server,
+                                                      DataSvc.DemoPath))
+                    {
+                        dl.Download();
+                    }
+
+                    break;
+                case "sftp":
+                    using (var dl = new SftpDownloader(testInfo, server,
+                                                       DataSvc.DemoPath))
+                    {
+                        dl.Download();
+                    }
+
+                    break;
+            }
+
+            Console.ResetColor();
+        }
+    }
+}

--- a/BotHATTwaffle/Objects/Downloader/DownloaderService.cs
+++ b/BotHATTwaffle/Objects/Downloader/DownloaderService.cs
@@ -4,26 +4,26 @@ using System.ComponentModel;
 using BotHATTwaffle.Modules.Json;
 
 namespace BotHATTwaffle.Objects.Downloader {
-    public class DownloaderService {
-        private DataServices DataSvc { get; }
+    public class DownloaderService
+    {
+        private readonly DataServices dataSvc;
+        private readonly BackgroundWorker worker;
 
-        private BackgroundWorker Worker { get; }
-
-        public DownloaderService(DataServices ds)
+        public DownloaderService(DataServices dataSvc)
         {
-            DataSvc = ds;
-            Worker = new BackgroundWorker();
+            this.dataSvc = dataSvc;
+            worker = new BackgroundWorker();
 
             // DownloadFiles is used as the DoWork event.
-            Worker.DoWork += DownloadFiles;
+            worker.DoWork += DownloadFiles;
         }
 
         public void Start(IReadOnlyList<string> testInfo, JsonServer server)
         {
-            if (!Worker.IsBusy)
+            if (!worker.IsBusy)
             {
                 // RunWorkerAsync raises the DoWork event.
-                Worker.RunWorkerAsync((DataSvc, testInfo, server));
+                worker.RunWorkerAsync((testInfo, server));
             }
         }
 
@@ -38,7 +38,7 @@ namespace BotHATTwaffle.Objects.Downloader {
                 case "ftps":
                 case "ftp":
                     using (var dl = new FtpDownloader(testInfo, server,
-                                                      DataSvc.DemoPath))
+                                                      dataSvc))
                     {
                         dl.Download();
                     }
@@ -46,7 +46,7 @@ namespace BotHATTwaffle.Objects.Downloader {
                     break;
                 case "sftp":
                     using (var dl = new SftpDownloader(testInfo, server,
-                                                       DataSvc.DemoPath))
+                                                       dataSvc))
                     {
                         dl.Download();
                     }

--- a/BotHATTwaffle/Objects/Downloader/FtpDownloader.cs
+++ b/BotHATTwaffle/Objects/Downloader/FtpDownloader.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Security.Authentication;
-using System.Text;
-using System.Threading.Tasks;
 using BotHATTwaffle.Modules.Json;
 using FluentFTP;
 
@@ -36,7 +33,16 @@ namespace BotHATTwaffle.Objects.Downloader
 
         public override void Download()
         {
-            Client.Connect();
+            try
+            {
+                Client.Connect();
+            }
+            catch (Exception e)
+            {
+                /*ChannelLog("Connection Failure",
+                           $"Failed to connect to the server.\n{e.Message}");*/
+                return;
+            }
 
             // Downloads the demo file.
             DownloadFile(GetFile(FtpPath, DemoName),

--- a/BotHATTwaffle/Objects/Downloader/FtpDownloader.cs
+++ b/BotHATTwaffle/Objects/Downloader/FtpDownloader.cs
@@ -10,14 +10,14 @@ namespace BotHATTwaffle.Objects.Downloader
 {
     public sealed class FtpDownloader : Downloader<FtpClient>
     {
-        private string Gamemode { get; }
+        private readonly string gamemode;
 
         public FtpDownloader(IReadOnlyList<string> testInfo,
                              JsonServer server,
-                             string demoPath) :
-            base(testInfo, server, demoPath)
+                             DataServices dataSvc) :
+            base(testInfo, server, dataSvc)
         {
-            Gamemode = testInfo[7];
+            gamemode = testInfo[7];
             Client =
                 new FtpClient(server.Address, server.FTPUser, server.FTPPass);
 
@@ -39,14 +39,15 @@ namespace BotHATTwaffle.Objects.Downloader
             }
             catch (Exception e)
             {
-                /*ChannelLog("Connection Failure",
-                           $"Failed to connect to the server.\n{e.Message}");*/
+                DataSvc.ChannelLog("Connection Failure",
+                                   "Failed to connect to the server.\n" +
+                                   $"{e.Message}");
                 return;
             }
 
             // Downloads the demo file.
             DownloadFile(GetFile(FtpPath, DemoName),
-                         $"{LocalPath}\\{DemoName}_{Gamemode}.dem");
+                         $"{LocalPath}\\{DemoName}_{gamemode}.dem");
 
             // Downloads the BSP file.
             string sourceBsp =
@@ -55,37 +56,36 @@ namespace BotHATTwaffle.Objects.Downloader
                          $"{LocalPath}\\{Path.GetFileName(sourceBsp)}");
 
             Client.Disconnect();
-            /*ChannelLog("Listing of Download Directory",
-                       $"{string.Join("\n", Directory.GetFiles(LocalPath))}");*/
+            DataSvc.ChannelLog("Listing of Download Directory",
+                               $"{string.Join("\n", Directory.GetFiles(LocalPath))}");
         }
 
         private void DownloadFile(string sourcePath, string destPath)
         {
             if (sourcePath == null)
             {
-                /*ChannelLog("File Not Found",
-                           "Failed to find the file on the server.");*/
+                DataSvc.ChannelLog("File Not Found",
+                                   "Failed to find the file on the server.");
                 return;
             }
 
-            /*ChannelLog("Downloading File From Playtest",
-                       $"{sourcePath}\n{destPath}");*/
+            DataSvc.ChannelLog("Downloading File From Playtest",
+                               $"{sourcePath}\n{destPath}");
 
             try {
                 if (!Client.DownloadFile(destPath, sourcePath)) {
-                    /*ChannelLog("Download Failed",
-                               "Failed to download the file.");*/
-                    return;
+                    DataSvc.ChannelLog("Download Failed",
+                                       "Failed to download the file.");
                 }
             } catch (Exception e)
             {
-                /*ChannelLog("Download Failed",
-                           $"Failed to download the file.\n{e.Message}");*/
-                return;
+                DataSvc.ChannelLog("Download Failed",
+                                   "Failed to download the file.\n" +
+                                   $"{e.Message}");
             }
 
-            /*ChannelLog("Download Completed",
-                       "Successfully downloaded the demo file.");*/
+            DataSvc.ChannelLog("Download Completed",
+                               "Successfully downloaded the demo file.");
         }
 
         private string GetFile(string path, string name)

--- a/BotHATTwaffle/Objects/Downloader/FtpDownloader.cs
+++ b/BotHATTwaffle/Objects/Downloader/FtpDownloader.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Authentication;
+using System.Text;
+using System.Threading.Tasks;
+using BotHATTwaffle.Modules.Json;
+using FluentFTP;
+
+namespace BotHATTwaffle.Objects.Downloader
+{
+    public sealed class FtpDownloader : Downloader<FtpClient>
+    {
+        private string Gamemode { get; }
+
+        public FtpDownloader(IReadOnlyList<string> testInfo,
+                             JsonServer server,
+                             string demoPath) :
+            base(testInfo, server, demoPath)
+        {
+            Gamemode = testInfo[7];
+            Client =
+                new FtpClient(server.Address, server.FTPUser, server.FTPPass);
+
+            if (server.FTPType == "ftps")
+            {
+                Client.EncryptionMode = FtpEncryptionMode.Explicit;
+                Client.SslProtocols = SslProtocols.Tls;
+
+                Client.ValidateCertificate +=
+                    (control, e) => { e.Accept = true; };
+            }
+        }
+
+        public override void Download()
+        {
+            Client.Connect();
+
+            // Downloads the demo file.
+            DownloadFile(GetFile(FtpPath, DemoName),
+                         $"{LocalPath}\\{DemoName}_{Gamemode}.dem");
+
+            // Downloads the BSP file.
+            string sourceBsp =
+                GetFile($"{FtpPath}/maps/workshop/{WorkshopId}", ".bsp");
+            DownloadFile(sourceBsp,
+                         $"{LocalPath}\\{Path.GetFileName(sourceBsp)}");
+
+            Client.Disconnect();
+            /*ChannelLog("Listing of Download Directory",
+                       $"{string.Join("\n", Directory.GetFiles(LocalPath))}");*/
+        }
+
+        private void DownloadFile(string sourcePath, string destPath)
+        {
+            if (sourcePath == null)
+            {
+                /*ChannelLog("File Not Found",
+                           "Failed to find the file on the server.");*/
+                return;
+            }
+
+            /*ChannelLog("Downloading File From Playtest",
+                       $"{sourcePath}\n{destPath}");*/
+
+            try {
+                if (!Client.DownloadFile(destPath, sourcePath)) {
+                    /*ChannelLog("Download Failed",
+                               "Failed to download the file.");*/
+                    return;
+                }
+            } catch (Exception e)
+            {
+                /*ChannelLog("Download Failed",
+                           $"Failed to download the file.\n{e.Message}");*/
+                return;
+            }
+
+            /*ChannelLog("Download Completed",
+                       "Successfully downloaded the demo file.");*/
+        }
+
+        private string GetFile(string path, string name)
+        {
+            // If default, null is returned because string is a reference type.
+            return Client.GetNameListing(path)
+                         .FirstOrDefault(f => f.ToLower()
+                                               .Contains(name.ToLower()));
+        }
+    }
+}

--- a/BotHATTwaffle/Objects/Downloader/SFtpDownloader.cs
+++ b/BotHATTwaffle/Objects/Downloader/SFtpDownloader.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BotHATTwaffle.Modules.Json;
 using Renci.SshNet;
 using Renci.SshNet.Sftp;
@@ -21,7 +19,14 @@ namespace BotHATTwaffle.Objects.Downloader {
 
         public override void Download()
         {
-            Client.Connect();
+            try {
+                Client.Connect();
+            } catch (Exception e) {
+                /*ChannelLog("Connection Failure",
+                           $"Failed to connect to the server.\n{e.Message}");*/
+                return;
+            }
+
             Directory.CreateDirectory(LocalPath);
 
             SftpFile fileDemo = GetFile(FtpPath, DemoName);

--- a/BotHATTwaffle/Objects/Downloader/SFtpDownloader.cs
+++ b/BotHATTwaffle/Objects/Downloader/SFtpDownloader.cs
@@ -10,8 +10,8 @@ namespace BotHATTwaffle.Objects.Downloader {
     public sealed class SftpDownloader : Downloader<SftpClient> {
         public SftpDownloader(IReadOnlyList<string> testInfo,
                               JsonServer server,
-                              string demoPath) :
-            base(testInfo, server, demoPath)
+                              DataServices dataSvc) :
+            base(testInfo, server, dataSvc)
         {
             Client =
                 new SftpClient(testInfo[10], server.FTPUser, server.FTPPass);
@@ -22,8 +22,9 @@ namespace BotHATTwaffle.Objects.Downloader {
             try {
                 Client.Connect();
             } catch (Exception e) {
-                /*ChannelLog("Connection Failure",
-                           $"Failed to connect to the server.\n{e.Message}");*/
+                DataSvc.ChannelLog("Connection Failure",
+                                   "Failed to connect to the server.\n" +
+                                   $"{e.Message}");
                 return;
             }
 
@@ -37,30 +38,31 @@ namespace BotHATTwaffle.Objects.Downloader {
             DownloadFile(fileBsp, $"{LocalPath}\\{fileBsp.Name}");
 
             Client.Disconnect();
-            /*ChannelLog("Listing of Download Directory",
-                       $"{string.Join("\n", Directory.GetFiles(LocalPath))}");*/
+            DataSvc.ChannelLog("Listing of Download Directory",
+                               $"{string.Join("\n", Directory.GetFiles(LocalPath))}");
         }
 
         private void DownloadFile(SftpFile file, string destPath)
         {
             if (file == null) {
-                /*ChannelLog("File Not Found",
-                           "Failed to find the file on the server.");*/
+                DataSvc.ChannelLog("File Not Found",
+                                   "Failed to find the file on the server.");
                 return;
             }
 
-            /*ChannelLog("Downloading File From Playtest",
-                       $"{file.FullName}\n{destPath}");*/
+            DataSvc.ChannelLog("Downloading File From Playtest",
+                               $"{file.FullName}\n{destPath}");
 
             try {
                 using (Stream stream = File.OpenWrite(destPath))
                     Client.DownloadFile(file.FullName, stream);
 
-                /*ChannelLog("Download Completed",
-                           "Successfully downloaded the demo file.");*/
+                DataSvc.ChannelLog("Download Completed",
+                                   "Successfully downloaded the demo file.");
             } catch (Exception e) {
-                /*ChannelLog("Download Failed",
-                           $"Failed to download the file.\n{e.Message}");*/
+                DataSvc.ChannelLog("Download Failed",
+                                   "Failed to download the file.\n" +
+                                   $"{e.Message}");
             }
         }
 

--- a/BotHATTwaffle/Objects/Downloader/SFtpDownloader.cs
+++ b/BotHATTwaffle/Objects/Downloader/SFtpDownloader.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BotHATTwaffle.Modules.Json;
+using Renci.SshNet;
+using Renci.SshNet.Sftp;
+
+namespace BotHATTwaffle.Objects.Downloader {
+    public sealed class SftpDownloader : Downloader<SftpClient> {
+        public SftpDownloader(IReadOnlyList<string> testInfo,
+                              JsonServer server,
+                              string demoPath) :
+            base(testInfo, server, demoPath)
+        {
+            Client =
+                new SftpClient(testInfo[10], server.FTPUser, server.FTPPass);
+        }
+
+        public override void Download()
+        {
+            Client.Connect();
+            Directory.CreateDirectory(LocalPath);
+
+            SftpFile fileDemo = GetFile(FtpPath, DemoName);
+            DownloadFile(fileDemo, $"{LocalPath}\\{fileDemo.Name}");
+
+            SftpFile fileBsp =
+                GetFile($"{FtpPath}/maps/workshop/{WorkshopId}", ".bsp");
+            DownloadFile(fileBsp, $"{LocalPath}\\{fileBsp.Name}");
+
+            Client.Disconnect();
+            /*ChannelLog("Listing of Download Directory",
+                       $"{string.Join("\n", Directory.GetFiles(LocalPath))}");*/
+        }
+
+        private void DownloadFile(SftpFile file, string destPath)
+        {
+            if (file == null) {
+                /*ChannelLog("File Not Found",
+                           "Failed to find the file on the server.");*/
+                return;
+            }
+
+            /*ChannelLog("Downloading File From Playtest",
+                       $"{file.FullName}\n{destPath}");*/
+
+            try {
+                using (Stream stream = File.OpenWrite(destPath))
+                    Client.DownloadFile(file.FullName, stream);
+
+                /*ChannelLog("Download Completed",
+                           "Successfully downloaded the demo file.");*/
+            } catch (Exception e) {
+                /*ChannelLog("Download Failed",
+                           $"Failed to download the file.\n{e.Message}");*/
+            }
+        }
+
+        private SftpFile GetFile(string path, string name)
+        {
+            return Client.ListDirectory(path)
+                         .FirstOrDefault(f => f.Name.ToLower()
+                                               .Contains(name.ToLower()));
+        }
+    }
+}

--- a/BotHATTwaffle/Program.cs
+++ b/BotHATTwaffle/Program.cs
@@ -7,9 +7,7 @@ using Discord.Commands;
 using Microsoft.Extensions.DependencyInjection;
 using BotHATTwaffle;
 using BotHATTwaffle.Modules;
-using System.IO;
-using System.Linq;
-using System.Collections.Generic;
+using BotHATTwaffle.Objects.Downloader;
 using Discord.Addons.Interactive;
 
 public class Program
@@ -38,6 +36,7 @@ public class Program
             .AddSingleton<Eavesdropping>()
             .AddSingleton<DataServices>()
             .AddSingleton<Random>()
+            .AddSingleton<DownloaderService>()
             .AddSingleton(s => new InteractiveService(_client, TimeSpan.FromSeconds(120)))
             .BuildServiceProvider();
 
@@ -95,14 +94,14 @@ public class Program
         // Determine if the message is a command, based on if it starts with '>' or a mention prefix
         if (!(message.HasCharPrefix(prefixChar, ref argPos) || message.HasMentionPrefix(_client.CurrentUser, ref argPos)))
         {
-#pragma warning disable CS4014 //The message isn't a command. Lets eavesdrop on it to see if we should do something else. We should not wait for this. Low priority. 
-            _eavesdrop.Listen(messageParam); 
+#pragma warning disable CS4014 //The message isn't a command. Lets eavesdrop on it to see if we should do something else. We should not wait for this. Low priority.
+            _eavesdrop.Listen(messageParam);
 #pragma warning restore CS4014
             return;
         }
         // Create a Command Context
         var context = new SocketCommandContext(_client, message);
-        // Execute the command. (result does not indicate a return value, 
+        // Execute the command. (result does not indicate a return value,
         // rather an object stating if the command executed successfully)
         var result = await _commands.ExecuteAsync(context, argPos, _services);
         if (!result.IsSuccess)
@@ -121,7 +120,7 @@ public class Program
 
             await _services.GetRequiredService<DataServices>().ChannelLog($"An error occurred!\nInvoking command: {context.Message}",
                 $"Invoking User: {message.Author}\nChannel: {message.Channel}\nError Reason: {result.ErrorReason}", alert);
-            
+
             Console.ResetColor();
         }
 


### PR DESCRIPTION
`FtpDownloader`, for FluentFTP, and `SftpDownloader`, for SSH.NET, inherit from the abstract class `Downloader`, which contains properties and functions that both children make use of in their implementations.

`DownloaderService` is used to instantiate the appropriate `Downloader` and download the files on a `BackgroundWorker`.

